### PR TITLE
在Linux下的使用状况及修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Emake 是为快速开发而生的，最初版本在 2009年发布，多年间团
 #### Linux / Mac OS X: 
 
 ```bash
-wget http://skywind3000.github.io/emake/emake.py
-sudo python2 emake.py -i
+wget https://raw.githubusercontent.com/shjlone/emake/master/emake.py
+sudo python emake.py -i
 ```
 
 运行上面两条指令，十秒内完成安装。emake 会拷贝自己到 /usr/local/bin 下面，后面直接使用 emake 指令操作。

--- a/emake.py
+++ b/emake.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/python
 # -*- coding: utf-8 -*-
 # ======================================================================
 #
@@ -27,6 +27,7 @@
 # 2017.08.16   skywind   new: cflag, cxxflag, sflag, mflag, mmflag
 # 2017.12.20   skywind   new: --abs=1 to tell gcc to print fullpath
 # 2020.11.11   aloneqd   new: python3版本
+# 2021.04.05   TD_Sky    set the script interpreter to /usr/bin/python
 #
 # ======================================================================
 import sys, time, os, io


### PR DESCRIPTION
Linux下使用emake命令时，脚本解释器依然是python2，现将此改为python3.

因为python3的emake没有合并到skywind3000的分支，所以把wget定位到你的项目下。